### PR TITLE
Rename web_socket to websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ fn counter() -> Html {
 ### Side-effects
 
 - `use_async` - resolves an `async` future, e.g. fetching REST api.
-- `use_web_socket` - communicates with `WebSocket`.
+- `use_websocket` - communicates with `WebSocket`.
 - `use_title` - sets title of the page.
 - `use_favicon` - sets favicon of the page.
 - `use_local_storage` - manages a value in `localStorage`.
@@ -305,7 +305,7 @@ enum Error {
 }
 ```
 
-### `use_web_socket` demo
+### `use_websocket` demo
 
 ```rust
 use yew::prelude::*;
@@ -314,7 +314,7 @@ use yew_hooks::prelude::*;
 #[function_component(UseWebSocket)]
 pub fn web_socket() -> Html {
     let history = use_list(vec![]);
-    let ws = use_web_socket("wss://echo.websocket.events/".to_string());
+    let ws = use_websocket("wss://echo.websocket.events/".to_string());
 
     let onclick = {
         let ws = ws.clone();

--- a/crates/yew-hooks/src/hooks/mod.rs
+++ b/crates/yew-hooks/src/hooks/mod.rs
@@ -49,7 +49,7 @@ mod use_title;
 mod use_toggle;
 mod use_unmount;
 mod use_update;
-mod use_web_socket;
+mod use_websocket;
 mod use_window_scroll;
 mod use_window_size;
 
@@ -104,6 +104,6 @@ pub use use_title::*;
 pub use use_toggle::*;
 pub use use_unmount::*;
 pub use use_update::*;
-pub use use_web_socket::*;
+pub use use_websocket::*;
 pub use use_window_scroll::*;
 pub use use_window_size::*;

--- a/crates/yew-hooks/src/hooks/use_web_socket.rs
+++ b/crates/yew-hooks/src/hooks/use_web_socket.rs
@@ -43,7 +43,7 @@ pub struct UseWebSocketOptions {
     pub protocols: Option<Vec<String>>,
 }
 
-/// State handle for the [`use_web_socket`] hook.
+/// State handle for the [`use_websocket`] hook.
 pub struct UseWebSocketHandle {
     /// The current state of the `WebSocket` connection.
     pub ready_state: UseStateHandle<UseWebSocketReadyState>,
@@ -111,7 +111,7 @@ impl Clone for UseWebSocketHandle {
 /// fn web_socket() -> Html {
 ///     let history = use_list(vec![]);
 ///
-///     let ws = use_web_socket("wss://echo.websocket.events/".to_string());
+///     let ws = use_websocket("wss://echo.websocket.events/".to_string());
 ///     let onclick = {
 ///         let ws = ws.clone();
 ///         let history = history.clone();
@@ -156,8 +156,8 @@ impl Clone for UseWebSocketHandle {
 /// }
 /// ```
 #[hook]
-pub fn use_web_socket(url: String) -> UseWebSocketHandle {
-    use_web_socket_with_options(url, UseWebSocketOptions::default())
+pub fn use_websocket(url: String) -> UseWebSocketHandle {
+    use_websocket_with_options(url, UseWebSocketOptions::default())
 }
 
 /// This hook communicates with `WebSocket` with options.
@@ -175,7 +175,7 @@ pub fn use_web_socket(url: String) -> UseWebSocketHandle {
 ///
 ///     let ws = {
 ///         let history = history.clone();
-///         use_web_socket_with_options(
+///         use_websocket_with_options(
 ///             "wss://echo.websocket.events/".to_string(),
 ///             UseWebSocketOptions {
 ///                 // Receive message by callback `onmessage`.
@@ -224,7 +224,7 @@ pub fn use_web_socket(url: String) -> UseWebSocketHandle {
 /// }
 /// ```
 #[hook]
-pub fn use_web_socket_with_options(
+pub fn use_websocket_with_options(
     url: String,
     options: UseWebSocketOptions,
 ) -> UseWebSocketHandle {

--- a/examples/yew-app/src/routes/home.rs
+++ b/examples/yew-app/src/routes/home.rs
@@ -36,7 +36,7 @@ pub fn home() -> Html {
 
                     <ul>
                         <li><Link<AppRoute> to={AppRoute::UseAsync} classes="app-link" >{ "use_async" }</Link<AppRoute>> { " - resolves an async future, e.g. fetching REST api." }</li>
-                        <li><Link<AppRoute> to={AppRoute::UseWebSocket} classes="app-link" >{ "use_web_socket" }</Link<AppRoute>> { " - communicates with WebSocket." }</li>
+                        <li><Link<AppRoute> to={AppRoute::UseWebSocket} classes="app-link" >{ "use_websocket" }</Link<AppRoute>> { " - communicates with WebSocket." }</li>
                         <li><Link<AppRoute> to={AppRoute::UseTitle} classes="app-link" >{ "use_title" }</Link<AppRoute>> { " - sets title of the page." }</li>
                         <li><Link<AppRoute> to={AppRoute::UseFavicon} classes="app-link" >{ "use_favicon" }</Link<AppRoute>> { " - sets favicon of the page." }</li>
                         <li><Link<AppRoute> to={AppRoute::UseLocalStorage} classes="app-link" >{ "use_local_storage" }</Link<AppRoute>> { " - manages a value in localStorage." }</li>

--- a/examples/yew-app/src/routes/hooks/mod.rs
+++ b/examples/yew-app/src/routes/hooks/mod.rs
@@ -51,7 +51,7 @@ mod use_title;
 mod use_toggle;
 mod use_unmount;
 mod use_update;
-mod use_web_socket;
+mod use_websocket;
 mod use_window_scroll;
 mod use_window_size;
 
@@ -108,6 +108,6 @@ pub use use_title::*;
 pub use use_toggle::*;
 pub use use_unmount::*;
 pub use use_update::*;
-pub use use_web_socket::*;
+pub use use_websocket::*;
 pub use use_window_scroll::*;
 pub use use_window_size::*;

--- a/examples/yew-app/src/routes/hooks/use_web_socket.rs
+++ b/examples/yew-app/src/routes/hooks/use_web_socket.rs
@@ -1,13 +1,13 @@
 use yew::prelude::*;
 use yew_hooks::prelude::*;
 
-/// `use_web_socket` demo
+/// `use_websocket` demo
 #[function_component(UseWebSocket)]
 pub fn web_socket() -> Html {
     let history = use_list(vec![]);
 
     // Demo #1, auto connect to websocket by default.
-    let ws = use_web_socket("wss://echo.websocket.events/".to_string());
+    let ws = use_websocket("wss://echo.websocket.events/".to_string());
     let onclick = {
         let ws = ws.clone();
         let history = history.clone();
@@ -60,7 +60,7 @@ pub fn web_socket() -> Html {
     // Demo #3, manually connect to websocket with custom options.
     let ws2 = {
         let history = history.clone();
-        use_web_socket_with_options(
+        use_websocket_with_options(
             "wss://echo.websocket.events/".to_string(),
             UseWebSocketOptions {
                 // Receive message by callback `onmessage`.

--- a/examples/yew-app/src/routes/mod.rs
+++ b/examples/yew-app/src/routes/mod.rs
@@ -80,7 +80,7 @@ pub enum AppRoute {
     UseSearchParam,
     #[at("/use_location")]
     UseLocation,
-    #[at("/use_web_socket")]
+    #[at("/use_websocket")]
     UseWebSocket,
     #[at("/use_state_ptr_eq")]
     UseStatePtrEq,


### PR DESCRIPTION
WebSocket is usually kept as one word.
This PR is to keep the naming consistent with user expectations.

Some examples:
1. [websocket crate](https://github.com/websockets-rs/rust-websocket/blob/74c82be3de282e1c4c35c51daac1a84b583ce8ea/src/server/upgrade/async.rs#L48)
2. [tungstenite crate](https://github.com/snapview/tungstenite-rs/blob/b473e19f7eef012611feadf81df7ec49c52c4a1a/src/handshake/client.rs#L88)
3. [gorilla/websocket in Go](https://github.com/gorilla/websocket/blob/af47554f343b4675b30172ac301638d350db34a5/example_test.go#L5)