### PR TITLE
Clippy fixes

### DIFF
--- a/crates/yew-hooks/src/hooks/use_async.rs
+++ b/crates/yew-hooks/src/hooks/use_async.rs
@@ -14,13 +14,13 @@ pub struct UseAsyncOptions {
 
 impl UseAsyncOptions {
     /// Automatically run when mount
-    pub fn enable_auto() -> Self {
+    pub const fn enable_auto() -> Self {
         Self { auto: true }
     }
 }
 
 /// State for an async future.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub struct UseAsyncState<T, E> {
     pub loading: bool,
     pub data: Option<T>,
@@ -36,7 +36,7 @@ pub struct UseAsyncHandle<T, E> {
 impl<T, E> UseAsyncHandle<T, E> {
     /// Start to resolve the async future to a final value.
     pub fn run(&self) {
-        (self.run)()
+        (self.run)();
     }
 
     /// Update `data` directly.
@@ -53,7 +53,7 @@ impl<T, E> Deref for UseAsyncHandle<T, E> {
     type Target = UseAsyncState<T, E>;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 
@@ -216,8 +216,8 @@ where
                     // Only set loading to true and leave previous data/error alone.
                     inner.set(UseAsyncState {
                         loading: true,
-                        data: (*inner).data.clone(),
-                        error: (*inner).error.clone(),
+                        data: inner.data.clone(),
+                        error: inner.error.clone(),
                     });
                     match future.await {
                         // Success with some data and clear previous error.
@@ -229,7 +229,7 @@ where
                         // Failed with some error and leave previous data alone.
                         Err(error) => inner.set(UseAsyncState {
                             loading: false,
-                            data: (*inner).data.clone(),
+                            data: inner.data.clone(),
                             error: Some(error),
                         }),
                     }

--- a/crates/yew-hooks/src/hooks/use_before_unload.rs
+++ b/crates/yew-hooks/src/hooks/use_before_unload.rs
@@ -36,5 +36,5 @@ pub fn use_before_unload(enabled: bool, msg: String) {
         // WebKit-derived browsers don't follow the spec for the dialog box.
         // We should return msg in the future for the event handler.
         // https://developer.mozilla.org/en-US/docs/Web/API/BeforeUnloadEvent
-    })
+    });
 }

--- a/crates/yew-hooks/src/hooks/use_clipboard.rs
+++ b/crates/yew-hooks/src/hooks/use_clipboard.rs
@@ -32,22 +32,22 @@ pub struct UseClipboardHandle {
 impl UseClipboardHandle {
     /// Read bytes from clipboard.
     pub fn read(&self) {
-        (self.read)()
+        (self.read)();
     }
 
     /// Read text from clipboard.
     pub fn read_text(&self) {
-        (self.read_text)()
+        (self.read_text)();
     }
 
     /// Write bytes with mime type to clipboard.
     pub fn write(&self, data: Vec<u8>, mime_type: Option<String>) {
-        (self.write)(data, mime_type)
+        (self.write)(data, mime_type);
     }
 
     /// Write text to clipboard.
     pub fn write_text(&self, data: String) {
-        (self.write_text)(data)
+        (self.write_text)(data);
     }
 }
 
@@ -205,7 +205,7 @@ pub fn use_clipboard() -> UseClipboardHandle {
                         let resolve_closure = Closure::wrap(Box::new(move |_| {
                             bytes.set(Some(data.clone()));
                             bytes_mime_type.set(mime_type.clone());
-                            copied.set(true)
+                            copied.set(true);
                         })
                             as Box<dyn FnMut(JsValue)>);
                         let reject_closure = Closure::wrap(Box::new(move |_| {
@@ -233,15 +233,18 @@ pub fn use_clipboard() -> UseClipboardHandle {
                 let text = text.clone();
                 let text2 = text.clone();
                 let resolve_closure = Closure::wrap(Box::new(move |data: JsValue| {
-                    if let Some(data) = data.as_string() {
-                        if data.is_empty() {
+                    data.as_string().map_or_else(
+                        || {
                             text.set(None);
-                        } else {
-                            text.set(Some(data));
-                        }
-                    } else {
-                        text.set(None);
-                    }
+                        },
+                        |data| {
+                            if data.is_empty() {
+                                text.set(None);
+                            } else {
+                                text.set(Some(data));
+                            }
+                        },
+                    );
                 }) as Box<dyn FnMut(JsValue)>);
                 let reject_closure = Closure::wrap(Box::new(move |_| {
                     text2.set(None);
@@ -352,8 +355,8 @@ pub fn use_clipboard() -> UseClipboardHandle {
         text,
         bytes,
         bytes_mime_type,
-        is_supported,
         copied,
+        is_supported,
         write_text,
         write,
         read_text,

--- a/crates/yew-hooks/src/hooks/use_counter.rs
+++ b/crates/yew-hooks/src/hooks/use_counter.rs
@@ -53,32 +53,32 @@ pub struct UseCounterHandle {
 impl UseCounterHandle {
     /// Increase by `1`.
     pub fn increase(&self) {
-        self.inner.dispatch(CounterAction::Increase)
+        self.inner.dispatch(CounterAction::Increase);
     }
 
     /// Increase by `delta`.
     pub fn increase_by(&self, delta: i32) {
-        self.inner.dispatch(CounterAction::IncreaseBy(delta))
+        self.inner.dispatch(CounterAction::IncreaseBy(delta));
     }
 
     /// Decrease by `1`.
     pub fn decrease(&self) {
-        self.inner.dispatch(CounterAction::Decrease)
+        self.inner.dispatch(CounterAction::Decrease);
     }
 
     /// Decrease by `delta`.
     pub fn decrease_by(&self, delta: i32) {
-        self.inner.dispatch(CounterAction::DecreaseBy(delta))
+        self.inner.dispatch(CounterAction::DecreaseBy(delta));
     }
 
     /// Set to `value`.
     pub fn set(&self, value: i32) {
-        self.inner.dispatch(CounterAction::Set(value))
+        self.inner.dispatch(CounterAction::Set(value));
     }
 
     /// Reset to initial value.
     pub fn reset(&self) {
-        self.inner.dispatch(CounterAction::Reset)
+        self.inner.dispatch(CounterAction::Reset);
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_debounce.rs
+++ b/crates/yew-hooks/src/hooks/use_debounce.rs
@@ -10,12 +10,12 @@ pub struct UseDebounceHandle {
 impl UseDebounceHandle {
     /// Run the debounce.
     pub fn run(&self) {
-        self.inner.reset()
+        self.inner.reset();
     }
 
     /// Cancel the debounce.
     pub fn cancel(&self) {
-        self.inner.cancel()
+        self.inner.cancel();
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_debounce_state.rs
+++ b/crates/yew-hooks/src/hooks/use_debounce_state.rs
@@ -14,7 +14,7 @@ pub struct UseDebounceStateHandle<T> {
 impl<T> UseDebounceStateHandle<T> {
     // Set the value.
     pub fn set(&self, value: T) {
-        (self.set)(value)
+        (self.set)(value);
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_debounce_state.rs
+++ b/crates/yew-hooks/src/hooks/use_debounce_state.rs
@@ -22,7 +22,7 @@ impl<T> Deref for UseDebounceStateHandle<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_default.rs
+++ b/crates/yew-hooks/src/hooks/use_default.rs
@@ -15,7 +15,7 @@ where
 {
     /// Replaces the value.
     pub fn set(&self, value: Option<T>) {
-        self.inner.set(value)
+        self.inner.set(value);
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_effect_update.rs
+++ b/crates/yew-hooks/src/hooks/use_effect_update.rs
@@ -36,10 +36,10 @@ where
     let first = use_is_first_mount();
 
     use_effect(move || {
-        if !first {
-            Box::new(callback())
-        } else {
+        if first {
             Box::new(|| ()) as Box<dyn FnOnce()>
+        } else {
+            Box::new(callback())
         }
     });
 }
@@ -59,10 +59,10 @@ pub fn use_effect_update_with_deps<Callback, Destructor, Dependents>(
 
     use_effect_with_deps(
         move |deps| {
-            if !first {
-                Box::new(callback(deps))
-            } else {
+            if first {
                 Box::new(|| ()) as Box<dyn FnOnce()>
+            } else {
+                Box::new(callback(deps))
             }
         },
         deps,

--- a/crates/yew-hooks/src/hooks/use_event.rs
+++ b/crates/yew-hooks/src/hooks/use_event.rs
@@ -47,7 +47,7 @@ where
             let window = window();
             let node = node.get();
             // If we cannot get the wrapped `Node`, then we use `Window` as the default target of the event.
-            let target = node.as_deref().map_or(window.deref(), |t| t);
+            let target = node.as_deref().map_or(&*window, |t| t);
 
             // We should only set passive event listeners for `touchstart` and `touchmove`.
             // See here: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Improving_scrolling_performance_with_passive_listeners

--- a/crates/yew-hooks/src/hooks/use_event.rs
+++ b/crates/yew-hooks/src/hooks/use_event.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::ops::Deref;
 
 use gloo::events::{EventListener, EventListenerOptions};
 use gloo::utils::window;

--- a/crates/yew-hooks/src/hooks/use_favicon.rs
+++ b/crates/yew-hooks/src/hooks/use_favicon.rs
@@ -50,5 +50,5 @@ pub fn use_favicon(href: String) {
             || ()
         },
         href,
-    )
+    );
 }

--- a/crates/yew-hooks/src/hooks/use_geolocation.rs
+++ b/crates/yew-hooks/src/hooks/use_geolocation.rs
@@ -133,7 +133,7 @@ pub fn use_geolocation_with_options(options: UseGeolocationOptions) -> UseGeoloc
                     .navigator()
                     .geolocation()
                     .unwrap_throw()
-                    .clear_watch(watch_id)
+                    .clear_watch(watch_id);
             }
         });
     }

--- a/crates/yew-hooks/src/hooks/use_hash.rs
+++ b/crates/yew-hooks/src/hooks/use_hash.rs
@@ -22,7 +22,7 @@ impl Deref for UseHashHandle {
     type Target = String;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_local_storage.rs
+++ b/crates/yew-hooks/src/hooks/use_local_storage.rs
@@ -36,7 +36,7 @@ impl<T> Deref for UseLocalStorageHandle<T> {
     type Target = Option<T>;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_local_storage.rs
+++ b/crates/yew-hooks/src/hooks/use_local_storage.rs
@@ -113,7 +113,7 @@ where
         use_event_with_window("storage", move |e: StorageEvent| {
             if let Some(k) = e.key() {
                 if k == *key {
-                    inner.set(LocalStorage::get(&*key).unwrap_or_default())
+                    inner.set(LocalStorage::get(&*key).unwrap_or_default());
                 }
             }
         });

--- a/crates/yew-hooks/src/hooks/use_measure.rs
+++ b/crates/yew-hooks/src/hooks/use_measure.rs
@@ -62,7 +62,7 @@ pub fn use_measure(node: NodeRef) -> UseMeasureState {
         use_effect_with_deps(
             move |node| {
                 let closure = Closure::wrap(Box::new(move |entries: Vec<ResizeObserverEntry>| {
-                    for entry in entries.iter() {
+                    for entry in &entries {
                         let rect = entry.content_rect();
                         state.set(UseMeasureState {
                             x: rect.x(),

--- a/crates/yew-hooks/src/hooks/use_media.rs
+++ b/crates/yew-hooks/src/hooks/use_media.rs
@@ -53,32 +53,32 @@ pub struct UseMediaHandle {
 impl UseMediaHandle {
     /// Play the media.
     pub fn play(&self) {
-        (self.play)()
+        (self.play)();
     }
 
     /// Pause the media.
     pub fn pause(&self) {
-        (self.pause)()
+        (self.pause)();
     }
 
     /// Mute the media.
     pub fn mute(&self) {
-        (self.mute)()
+        (self.mute)();
     }
 
     /// Unmute the media.
     pub fn unmute(&self) {
-        (self.unmute)()
+        (self.unmute)();
     }
 
     /// Set volume of the media.
     pub fn set_volume(&self, value: f64) {
-        (self.set_volume)(value)
+        (self.set_volume)(value);
     }
 
     /// Seek the media.
     pub fn seek(&self, value: f64) {
-        (self.seek)(value)
+        (self.seek)(value);
     }
 }
 
@@ -459,7 +459,7 @@ fn parse_time_ranges(ranges: TimeRanges) -> Vec<(f64, f64)> {
             result.push((
                 ranges.start(index).unwrap_throw(),
                 ranges.end(index).unwrap_throw(),
-            ))
+            ));
         }
     }
     result

--- a/crates/yew-hooks/src/hooks/use_previous.rs
+++ b/crates/yew-hooks/src/hooks/use_previous.rs
@@ -19,7 +19,7 @@ impl<T> Deref for UsePreviousHandle<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_raf.rs
+++ b/crates/yew-hooks/src/hooks/use_raf.rs
@@ -52,10 +52,11 @@ pub fn use_raf(millis: u32, delay: u32) -> f64 {
                         if *start.borrow() <= 0f64 {
                             *start.borrow_mut() = time;
                         }
-                        let time =
-                            min_by(1f64, (time - *start.borrow()) / (millis as f64), |x, y| {
-                                x.partial_cmp(y).unwrap()
-                            });
+                        let time = min_by(
+                            1f64,
+                            (time - *start.borrow()) / f64::from(millis),
+                            |x, y| x.partial_cmp(y).unwrap(),
+                        );
                         elapsed.set(time);
 
                         // Schedule ourself for another requestAnimationFrame callback.

--- a/crates/yew-hooks/src/hooks/use_raf_state.rs
+++ b/crates/yew-hooks/src/hooks/use_raf_state.rs
@@ -29,7 +29,7 @@ impl<T> Deref for UseRafStateHandle<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_session_storage.rs
+++ b/crates/yew-hooks/src/hooks/use_session_storage.rs
@@ -33,7 +33,7 @@ impl<T> Deref for UseSessionStorageHandle<T> {
     type Target = Option<T>;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_size.rs
+++ b/crates/yew-hooks/src/hooks/use_size.rs
@@ -38,7 +38,7 @@ pub fn use_size(node: NodeRef) -> (u32, u32) {
         use_effect_with_deps(
             move |node| {
                 let closure = Closure::wrap(Box::new(move |entries: Vec<ResizeObserverEntry>| {
-                    for entry in entries.iter() {
+                    for entry in &entries {
                         let element = entry.target();
                         state.set((
                             element.client_width() as u32,

--- a/crates/yew-hooks/src/hooks/use_state_ptr_eq.rs
+++ b/crates/yew-hooks/src/hooks/use_state_ptr_eq.rs
@@ -31,7 +31,7 @@ pub struct UseStatePtrEqHandle<T> {
 impl<T> UseStatePtrEqHandle<T> {
     /// Replaces the value
     pub fn set(&self, value: T) {
-        self.inner.dispatch(value)
+        self.inner.dispatch(value);
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_swipe.rs
+++ b/crates/yew-hooks/src/hooks/use_swipe.rs
@@ -6,7 +6,7 @@ use yew::prelude::*;
 use super::{use_event, use_mut_latest};
 
 /// Swipe direction.
-#[derive(PartialEq, Clone, Debug)]
+#[derive(PartialEq, Eq, Clone, Debug)]
 pub enum UseSwipeDirection {
     Up,
     Right,
@@ -163,13 +163,13 @@ pub fn use_swipe_with_options(node: NodeRef, options: UseSwipeOptions) -> UseSwi
     let diff_x = {
         let coords_start = coords_start.clone();
         let coords_end = coords_end.clone();
-        Rc::new(move || ((*coords_start).0 - (*coords_end).0) as i32)
+        Rc::new(move || (coords_start.0 - coords_end.0) as i32)
     };
 
     let diff_y = {
         let coords_start = coords_start.clone();
         let coords_end = coords_end.clone();
-        Rc::new(move || ((*coords_start).1 - (*coords_end).1) as i32)
+        Rc::new(move || (coords_start.1 - coords_end.1) as i32)
     };
 
     let ontouchend = {

--- a/crates/yew-hooks/src/hooks/use_throttle.rs
+++ b/crates/yew-hooks/src/hooks/use_throttle.rs
@@ -13,12 +13,12 @@ pub struct UseThrottleHandle {
 impl UseThrottleHandle {
     /// Run the throttle.
     pub fn run(&self) {
-        (self.run)()
+        (self.run)();
     }
 
     /// Cancel the throttle.
     pub fn cancel(&self) {
-        (self.cancel)()
+        (self.cancel)();
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_throttle_state.rs
+++ b/crates/yew-hooks/src/hooks/use_throttle_state.rs
@@ -22,7 +22,7 @@ impl<T> Deref for UseThrottleStateHandle<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
-        &(*self.inner)
+        &self.inner
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_throttle_state.rs
+++ b/crates/yew-hooks/src/hooks/use_throttle_state.rs
@@ -14,7 +14,7 @@ pub struct UseThrottleStateHandle<T> {
 impl<T> UseThrottleStateHandle<T> {
     // Set the value.
     pub fn set(&self, value: T) {
-        (self.set)(value)
+        (self.set)(value);
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_timeout.rs
+++ b/crates/yew-hooks/src/hooks/use_timeout.rs
@@ -14,12 +14,12 @@ pub struct UseTimeoutHandle {
 impl UseTimeoutHandle {
     /// Reset the timeout.
     pub fn reset(&self) {
-        (self.reset)()
+        (self.reset)();
     }
 
     /// Cancel the timeout.
     pub fn cancel(&self) {
-        (self.cancel)()
+        (self.cancel)();
     }
 }
 

--- a/crates/yew-hooks/src/hooks/use_title.rs
+++ b/crates/yew-hooks/src/hooks/use_title.rs
@@ -30,6 +30,6 @@ pub fn use_title(title: String) {
     }
 
     use_unmount(move || {
-        gloo::utils::document().set_title(&*pre_title);
+        gloo::utils::document().set_title(&pre_title);
     });
 }

--- a/crates/yew-hooks/src/hooks/use_toggle.rs
+++ b/crates/yew-hooks/src/hooks/use_toggle.rs
@@ -36,9 +36,8 @@ where
                     self.left.clone()
                 }
             }
-            ToggleAction::Reset => self.left.clone(),
             ToggleAction::Set(value) => Rc::new(value),
-            ToggleAction::SetLeft => self.left.clone(),
+            ToggleAction::Reset | ToggleAction::SetLeft => self.left.clone(),
             ToggleAction::SetRight => self.right.clone(),
         };
 
@@ -74,27 +73,27 @@ where
 {
     /// Toggle the value.
     pub fn toggle(&self) {
-        self.inner.dispatch(ToggleAction::Toggle)
+        self.inner.dispatch(ToggleAction::Toggle);
     }
 
     /// Set to a value.
     pub fn set(&self, value: T) {
-        self.inner.dispatch(ToggleAction::Set(value))
+        self.inner.dispatch(ToggleAction::Set(value));
     }
 
     /// Set to the left default value.
     pub fn set_left(&self) {
-        self.inner.dispatch(ToggleAction::SetLeft)
+        self.inner.dispatch(ToggleAction::SetLeft);
     }
 
     /// Set to the right other value.
     pub fn set_right(&self) {
-        self.inner.dispatch(ToggleAction::SetRight)
+        self.inner.dispatch(ToggleAction::SetRight);
     }
 
     /// Reset to the default value.
     pub fn reset(&self) {
-        self.inner.dispatch(ToggleAction::Reset)
+        self.inner.dispatch(ToggleAction::Reset);
     }
 }
 
@@ -129,10 +128,7 @@ where
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for UseToggleHandle<T>
-where
-    T: PartialEq,
-{
+impl<T: fmt::Debug + PartialEq> fmt::Debug for UseToggleHandle<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("UseToggleHandle")
             .field("value", &format!("{:?}", self.inner.value))

--- a/crates/yew-hooks/src/hooks/use_websocket.rs
+++ b/crates/yew-hooks/src/hooks/use_websocket.rs
@@ -11,7 +11,7 @@ use super::{use_mut_latest, use_state_ptr_eq, use_unmount, UseStatePtrEqHandle};
 pub use web_sys::CloseEvent;
 
 /// The current state of the `WebSocket` connection.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum UseWebSocketReadyState {
     Connecting,
     Open,
@@ -294,7 +294,7 @@ pub fn use_websocket_with_options(url: String, options: UseWebSocketOptions) -> 
             *reconnect_timer_ref.borrow_mut() = None;
 
             {
-                let web_socket: &mut Option<WebSocket> = &mut *ws.borrow_mut();
+                let web_socket: &mut Option<WebSocket> = &mut ws.borrow_mut();
                 if let Some(web_socket) = web_socket {
                     let _ = web_socket.close();
                 }
@@ -432,7 +432,7 @@ pub fn use_websocket_with_options(url: String, options: UseWebSocketOptions) -> 
         let ws = ws.clone();
         Rc::new(move |data: String| {
             if *ready_state == UseWebSocketReadyState::Open {
-                let web_socket: &mut Option<WebSocket> = &mut *ws.borrow_mut();
+                let web_socket: &mut Option<WebSocket> = &mut ws.borrow_mut();
                 if let Some(web_socket) = web_socket {
                     let _ = web_socket.send_with_str(&data);
                 }
@@ -445,7 +445,7 @@ pub fn use_websocket_with_options(url: String, options: UseWebSocketOptions) -> 
         let ws = ws.clone();
         Rc::new(move |data: Vec<u8>| {
             if *ready_state == UseWebSocketReadyState::Open {
-                let web_socket: &mut Option<WebSocket> = &mut *ws.borrow_mut();
+                let web_socket: &mut Option<WebSocket> = &mut ws.borrow_mut();
                 if let Some(web_socket) = web_socket {
                     let _ = web_socket.send_with_u8_array(&data);
                 }
@@ -469,7 +469,7 @@ pub fn use_websocket_with_options(url: String, options: UseWebSocketOptions) -> 
             *reconnect_timer_ref.borrow_mut() = None;
             *reconnect_times_ref.borrow_mut() = reconnect_limit;
 
-            let web_socket: &mut Option<WebSocket> = &mut *ws.borrow_mut();
+            let web_socket: &mut Option<WebSocket> = &mut ws.borrow_mut();
             if let Some(web_socket) = web_socket {
                 let _ = web_socket.close();
             }

--- a/crates/yew-hooks/src/hooks/use_websocket.rs
+++ b/crates/yew-hooks/src/hooks/use_websocket.rs
@@ -63,22 +63,22 @@ pub struct UseWebSocketHandle {
 impl UseWebSocketHandle {
     /// Connect `WebSocket` manually. If already connected, close the current one and reconnect.
     pub fn open(&self) {
-        (self.open)()
+        (self.open)();
     }
 
     /// Disconnect `WebSocket` manually.
     pub fn close(&self) {
-        (self.close)()
+        (self.close)();
     }
 
     /// Send text message to `WebSocket`.
     pub fn send(&self, data: String) {
-        (self.send)(data)
+        (self.send)(data);
     }
 
     /// Send binary message to `WebSocket`.
     pub fn send_bytes(&self, data: Vec<u8>) {
-        (self.send_bytes)(data)
+        (self.send_bytes)(data);
     }
 }
 
@@ -301,15 +301,17 @@ pub fn use_websocket_with_options(url: String, options: UseWebSocketOptions) -> 
             }
 
             let web_socket = {
-                if let Some(protocols) = &protocols {
-                    let array = protocols
-                        .iter()
-                        .map(|p| JsValue::from(p.clone()))
-                        .collect::<Array>();
-                    WebSocket::new_with_str_sequence(&url, &JsValue::from(&array)).unwrap_throw()
-                } else {
-                    WebSocket::new(&url).unwrap_throw()
-                }
+                protocols.as_ref().map_or_else(
+                    || WebSocket::new(&url).unwrap_throw(),
+                    |protocols| {
+                        let array = protocols
+                            .iter()
+                            .map(|p| JsValue::from(p.clone()))
+                            .collect::<Array>();
+                        WebSocket::new_with_str_sequence(&url, &JsValue::from(&array))
+                            .unwrap_throw()
+                    },
+                )
             };
             web_socket.set_binary_type(BinaryType::Arraybuffer);
             ready_state.set(UseWebSocketReadyState::Connecting);
@@ -346,28 +348,36 @@ pub fn use_websocket_with_options(url: String, options: UseWebSocketOptions) -> 
                         return;
                     }
 
-                    if let Ok(array_buffer) = e.data().dyn_into::<js_sys::ArrayBuffer>() {
-                        let array = js_sys::Uint8Array::new(&array_buffer);
-                        let array = array.to_vec();
-                        let onmessage_bytes_ref = onmessage_bytes_ref.current();
-                        let onmessage_bytes = &mut *onmessage_bytes_ref.borrow_mut();
-                        if let Some(onmessage_bytes) = onmessage_bytes {
-                            let array = array.clone();
-                            onmessage_bytes(array);
-                        }
-                        message_bytes.set(Some(array));
-                    } else if let Ok(txt) = e.data().dyn_into::<js_sys::JsString>() {
-                        let txt = String::from(&txt);
-                        let onmessage_ref = onmessage_ref.current();
-                        let onmessage = &mut *onmessage_ref.borrow_mut();
-                        if let Some(onmessage) = onmessage {
-                            let txt = txt.clone();
-                            onmessage(txt);
-                        }
-                        message.set(Some(txt));
-                    } else {
-                        unreachable!("message event, received Unknown: {:?}", e.data());
-                    }
+                    e.data().dyn_into::<js_sys::ArrayBuffer>().map_or_else(
+                        |_| {
+                            e.data().dyn_into::<js_sys::JsString>().map_or_else(
+                                |_| {
+                                    unreachable!("message event, received Unknown: {:?}", e.data());
+                                },
+                                |txt| {
+                                    let txt = String::from(&txt);
+                                    let onmessage_ref = onmessage_ref.current();
+                                    let onmessage = &mut *onmessage_ref.borrow_mut();
+                                    if let Some(onmessage) = onmessage {
+                                        let txt = txt.clone();
+                                        onmessage(txt);
+                                    }
+                                    message.set(Some(txt));
+                                },
+                            );
+                        },
+                        |array_buffer| {
+                            let array = js_sys::Uint8Array::new(&array_buffer);
+                            let array = array.to_vec();
+                            let onmessage_bytes_ref = onmessage_bytes_ref.current();
+                            let onmessage_bytes = &mut *onmessage_bytes_ref.borrow_mut();
+                            if let Some(onmessage_bytes) = onmessage_bytes {
+                                let array = array.clone();
+                                onmessage_bytes(array);
+                            }
+                            message_bytes.set(Some(array));
+                        },
+                    );
                 })
                     as Box<dyn FnMut(MessageEvent)>);
                 web_socket.set_onmessage(Some(onmessage_closure.as_ref().unchecked_ref()));

--- a/examples/yew-app/src/routes/hooks/use_async.rs
+++ b/examples/yew-app/src/routes/hooks/use_async.rs
@@ -55,31 +55,23 @@ pub fn async_demo() -> Html {
                         }
                     </p>
                     {
-                        if let Some(repo) = &state.data {
-                            html! {
-                                <>
-                                    <p>{ "Repo name: " }<b>{ &repo.name }</b></p>
-                                    <p>{ "Repo full name: " }<b>{ &repo.full_name }</b></p>
-                                    <p>{ "Repo description: " }<b>{ &repo.description }</b></p>
+                        state.data.as_ref().map_or_else(|| html! {}, |repo| html! {
+                            <>
+                                <p>{ "Repo name: " }<b>{ &repo.name }</b></p>
+                                <p>{ "Repo full name: " }<b>{ &repo.full_name }</b></p>
+                                <p>{ "Repo description: " }<b>{ &repo.description }</b></p>
 
-                                    <p>{ "Owner name: " }<b>{ &repo.owner.login }</b></p>
-                                    <p>{ "Owner avatar: " }<b><br/><img alt="avatar" src={repo.owner.avatar_url.clone()} /></b></p>
-                                </>
-                                }
-                        } else {
-                            html! {}
-                        }
+                                <p>{ "Owner name: " }<b>{ &repo.owner.login }</b></p>
+                                <p>{ "Owner avatar: " }<b><br/><img alt="avatar" src={repo.owner.avatar_url.clone()} /></b></p>
+                            </>
+                            })
                     }
                     <p>
                         {
-                            if let Some(error) = &state.error {
-                                match error {
-                                    Error::DeserializeError => html! { "DeserializeError" },
-                                    Error::RequestError => html! { "RequestError" },
-                                }
-                            } else {
-                                html! {}
-                            }
+                            state.error.as_ref().map_or_else(|| html! {}, |error| match error {
+                                Error::DeserializeError => html! { "DeserializeError" },
+                                Error::RequestError => html! { "RequestError" },
+                            })
                         }
                     </p>
                 </div>
@@ -99,11 +91,7 @@ where
 {
     let response = reqwest::get(url).await;
     if let Ok(data) = response {
-        if let Ok(repo) = data.json::<T>().await {
-            Ok(repo)
-        } else {
-            Err(Error::DeserializeError)
-        }
+        (data.json::<T>().await).map_or(Err(Error::DeserializeError), |repo| Ok(repo))
     } else {
         Err(Error::RequestError)
     }

--- a/examples/yew-app/src/routes/hooks/use_clipboard.rs
+++ b/examples/yew-app/src/routes/hooks/use_clipboard.rs
@@ -12,11 +12,7 @@ pub fn update() -> Html {
             )
             .await
             {
-                if let Ok(bytes) = response.bytes().await {
-                    Ok(bytes.to_vec())
-                } else {
-                    Err("Bytes error")
-                }
+                (response.bytes().await).map_or(Err("Bytes error"), |bytes| Ok(bytes.to_vec()))
             } else {
                 Err("Response err")
             }

--- a/examples/yew-app/src/routes/hooks/use_debounce.rs
+++ b/examples/yew-app/src/routes/hooks/use_debounce.rs
@@ -6,8 +6,8 @@ use yew_hooks::prelude::*;
 #[function_component(UseDebounce)]
 pub fn debounce() -> Html {
     let status = use_state(|| "Typing stopped".to_string());
-    let value = use_state(|| "".to_string());
-    let debounced_value = use_state(|| "".to_string());
+    let value = use_state(String::new);
+    let debounced_value = use_state(String::new);
 
     let debounce = {
         let status = status.clone();

--- a/examples/yew-app/src/routes/hooks/use_debounce_effect.rs
+++ b/examples/yew-app/src/routes/hooks/use_debounce_effect.rs
@@ -6,8 +6,8 @@ use yew_hooks::prelude::*;
 #[function_component(UseDebounceEffect)]
 pub fn debounce_effect() -> Html {
     let status = use_state(|| "Typing stopped".to_string());
-    let value = use_state(|| "".to_string());
-    let debounced_value = use_state(|| "".to_string());
+    let value = use_state(String::new);
+    let debounced_value = use_state(String::new);
 
     {
         let status = status.clone();

--- a/examples/yew-app/src/routes/hooks/use_debounce_state.rs
+++ b/examples/yew-app/src/routes/hooks/use_debounce_state.rs
@@ -5,8 +5,8 @@ use yew_hooks::prelude::*;
 /// `use_debounce_state` demo
 #[function_component(UseDebounceState)]
 pub fn debounce_state() -> Html {
-    let value = use_state(|| "".to_string());
-    let debounced_value = use_debounce_state(|| "".to_string(), 2000);
+    let value = use_state(String::new);
+    let debounced_value = use_debounce_state(String::new, 2000);
 
     let oninput = {
         let value = value.clone();

--- a/examples/yew-app/src/routes/hooks/use_drag.rs
+++ b/examples/yew-app/src/routes/hooks/use_drag.rs
@@ -53,11 +53,10 @@ pub fn drag() -> Html {
                     } else {
                         "background-color: #61dafb; border: 3px dashed white; margin-top: 20px;" }}>
                     <p><b>{ " Text: " }</b></p>
-                        {if let Some(text) = &*state.text {
-                            html! {<p>{ text }</p>}
-                        } else {
-                            html! {}
-                        }}
+                        {
+                            (*state.text).as_ref().map_or_else(|| html! {},
+                                                               |text| html! {<p>{ text }</p>})
+                        }
                     <p>
                         { "Try to drop something to this area" }
                     </p>

--- a/examples/yew-app/src/routes/hooks/use_drop.rs
+++ b/examples/yew-app/src/routes/hooks/use_drop.rs
@@ -27,25 +27,28 @@ pub fn drop() -> Html {
                     } else {
                         "background-color: #61dafb; border: 3px dashed white;" }}>
                     <p><b>{ " Files: " }</b></p>
-                    {if let Some(files) = &*state.files {
-                        html! {for files.iter().map(|file| {
-                            html! { <p> { file.name() }</p> }
-                        })}
-                    } else {
-                        html! {}
-                    }}
+                    {
+                        (*state.files).as_ref().map_or_else(
+                            || html! {},
+                            |files| {
+                                html! {for files.iter().map(|file| {
+                                    html! { <p> { file.name() }</p> }
+                                })}
+                            },
+                        )
+                    }
                     <p><b>{ " Text: " }</b></p>
-                    {if let Some(text) = &*state.text {
-                        html! {<p>{ text }</p>}
-                    } else {
-                        html! {}
-                    }}
+                    {
+                        (*state.text)
+                            .as_ref()
+                            .map_or_else(|| html! {}, |text| html! {<p>{ text }</p>})
+                    }
                     <p><b>{ " Uri: " }</b></p>
-                    {if let Some(uri) = &*state.uri {
-                        html! {<p>{ uri }</p>}
-                    } else {
-                        html! {}
-                    }}
+                    {
+                        (*state.uri)
+                            .as_ref()
+                            .map_or_else(|| html! {}, |uri| html! {<p>{ uri }</p>})
+                    }
                     <p>
                         { "Try to drag & drop or copy & paste something here, e.g. files, links or text" }
                     </p>

--- a/examples/yew-app/src/routes/hooks/use_local_storage.rs
+++ b/examples/yew-app/src/routes/hooks/use_local_storage.rs
@@ -19,7 +19,7 @@ pub fn local_storage() -> Html {
             storage.set(User {
                 name: String::from("Jet Li"),
                 token: String::from("jwt_token"),
-            })
+            });
         })
     };
     let ondelete = {
@@ -32,8 +32,11 @@ pub fn local_storage() -> Html {
             <header class="app-header">
                 <div>
                     {
-                        if let Some(user) = &*storage {
-                            html! {
+                        (*storage).as_ref().map_or_else(|| html! {
+                                <>
+                                    <button onclick={onclick}>{ "Sign in" }</button>
+                                </>
+                            }, |user| html! {
                                 <>
                                     <button onclick={ondelete}>{ "Logout" }</button>
                                     <p>
@@ -41,14 +44,7 @@ pub fn local_storage() -> Html {
                                         { &user.name } { " - " } { &user.token }
                                     </p>
                                 </>
-                                }
-                        } else {
-                            html! {
-                                <>
-                                    <button onclick={onclick}>{ "Sign in" }</button>
-                                </>
-                            }
-                        }
+                        })
                     }
                 </div>
             </header>

--- a/examples/yew-app/src/routes/hooks/use_session_storage.rs
+++ b/examples/yew-app/src/routes/hooks/use_session_storage.rs
@@ -24,11 +24,9 @@ pub fn session_storage() -> Html {
                     <p>
                         <b>{ "Current value: " }</b>
                         {
-                            if let Some(value) = &*storage {
-                                html! { value }
-                            } else {
-                                html! {}
-                            }
+                            (*storage)
+                                .as_ref()
+                                .map_or_else(|| html! {}, |value| html! { value })
                         }
                     </p>
                 </div>

--- a/examples/yew-app/src/routes/hooks/use_state_ptr_eq.rs
+++ b/examples/yew-app/src/routes/hooks/use_state_ptr_eq.rs
@@ -4,7 +4,7 @@ use yew_hooks::prelude::*;
 /// `use_state_ptr_eq` demo
 #[function_component(UseStatePtrEq)]
 pub fn state_ptr_eq() -> Html {
-    let state = use_state_ptr_eq(|| "".to_string());
+    let state = use_state_ptr_eq(String::new);
     let history = use_list(vec![]);
 
     let onclick = {

--- a/examples/yew-app/src/routes/hooks/use_state_ptr_eq.rs
+++ b/examples/yew-app/src/routes/hooks/use_state_ptr_eq.rs
@@ -18,7 +18,7 @@ pub fn state_ptr_eq() -> Html {
         // This effect will not run if use `use_state` or `use_state_eq`.
         use_effect_with_deps(
             move |message| {
-                history.push((&**message).clone());
+                history.push((**message).clone());
 
                 || ()
             },

--- a/examples/yew-app/src/routes/hooks/use_throttle_effect.rs
+++ b/examples/yew-app/src/routes/hooks/use_throttle_effect.rs
@@ -14,7 +14,7 @@ pub fn throttle_effect() -> Html {
                 state.set(*state + 1);
             },
             2000,
-        )
+        );
     };
 
     let onclick = { Callback::from(move |_| update()) };

--- a/examples/yew-app/src/routes/hooks/use_websocket.rs
+++ b/examples/yew-app/src/routes/hooks/use_websocket.rs
@@ -37,7 +37,7 @@ pub fn web_socket() -> Html {
         let ws = ws.clone();
         let history = history.clone();
         Callback::from(move |_| {
-            let message = "Hello, world!\r\n".as_bytes().to_vec();
+            let message = b"Hello, world!\r\n".to_vec();
             ws.send_bytes(message.clone());
             history.push(format!("ws1 [send]: bytes {:?}", message));
         })

--- a/examples/yew-app/src/routes/mod.rs
+++ b/examples/yew-app/src/routes/mod.rs
@@ -10,7 +10,7 @@ use home::Home;
 use hooks::*;
 
 /// App routes
-#[derive(Routable, Debug, Clone, PartialEq)]
+#[derive(Routable, Debug, Clone, PartialEq, Eq)]
 pub enum AppRoute {
     #[at("/about")]
     About,

--- a/examples/yew-app/src/routes/mod.rs
+++ b/examples/yew-app/src/routes/mod.rs
@@ -7,7 +7,7 @@ pub mod hooks;
 
 use about::About;
 use home::Home;
-use hooks::{UseAsync, UseBeforeUnload, UseBoolToggle, UseClickAway, UseClipboard, UseCounter, UseDebounce, UseDebounceEffect, UseDebounceState, UseDefault, UseDrag, UseDrop, UseEffectOnce, UseEffectUpdate, UseEvent, UseFavicon, UseGeolocation, UseHash, UseInfiniteScroll, UseInterval, UseIsFirstMount, UseIsMounted, UseLatest, UseList, UseLocalStorage, UseLocation, UseLogger, UseMap, UseMeasure, UseMedia, UseMount, UseMutLatest, UsePrevious, UseQueue, UseRaf, UseRafState, UseRendersCount, UseScroll, UseScrolling, UseSearchParam, UseSessionStorage, UseSet, UseSize, UseStatePtrEq, UseSwipe, UseThrottle, UseThrottleEffect, UseThrottleState, UseTimeout, UseTitle, UseToggle, UseUnmount, UseUpdate, UseWebSocket, UseWindowScroll, UseWindowSize};
+use hooks::*;
 
 /// App routes
 #[derive(Routable, Debug, Clone, PartialEq, Eq)]

--- a/examples/yew-app/src/routes/mod.rs
+++ b/examples/yew-app/src/routes/mod.rs
@@ -7,7 +7,7 @@ pub mod hooks;
 
 use about::About;
 use home::Home;
-use hooks::*;
+use hooks::{UseAsync, UseBeforeUnload, UseBoolToggle, UseClickAway, UseClipboard, UseCounter, UseDebounce, UseDebounceEffect, UseDebounceState, UseDefault, UseDrag, UseDrop, UseEffectOnce, UseEffectUpdate, UseEvent, UseFavicon, UseGeolocation, UseHash, UseInfiniteScroll, UseInterval, UseIsFirstMount, UseIsMounted, UseLatest, UseList, UseLocalStorage, UseLocation, UseLogger, UseMap, UseMeasure, UseMedia, UseMount, UseMutLatest, UsePrevious, UseQueue, UseRaf, UseRafState, UseRendersCount, UseScroll, UseScrolling, UseSearchParam, UseSessionStorage, UseSet, UseSize, UseStatePtrEq, UseSwipe, UseThrottle, UseThrottleEffect, UseThrottleState, UseTimeout, UseTitle, UseToggle, UseUnmount, UseUpdate, UseWebSocket, UseWindowScroll, UseWindowSize};
 
 /// App routes
 #[derive(Routable, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
This is mostly consideration but this passes following clippy checks 
```
-W clippy::all -W clippy::pedantic -W clippy::nursery -W clippy::cargo -A clippy::cargo-common-metadata -A clippy::module-name-repetitions -A clippy::must-use-candidate -A clippy::let-underscore-drop -A clippy::needless-pass-by-value -A clippy::cast-sign-loss -A clippy::cast-possible-wrap -A clippy::use-self -A clippy::implicit-hasher
```

Notable allows:
 - `cast-sign-loss`/`cast-possible-wrap` - disabled because we are getting values from JS, and this is for sizes, I do not think that window size will overflow i32 anytime soon
 - `implicit-hasher` - while it would be nice to allow other hashers this overcomplicates the fixes
 - `use-self` - happens in web binds mostly and there is no way to fix this

This probably needs to run tests and make sure it does not break anything, i.e. feel free to reject this(plus it is big)