### PR TITLE
Allow cloning the UseAsyncState, if possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ Cargo.lock
 **/*.rs.bk
 
 /.vscode/
+
+# Ignore IntelliJ project files
+.idea/

--- a/crates/yew-hooks/src/hooks/use_async.rs
+++ b/crates/yew-hooks/src/hooks/use_async.rs
@@ -20,7 +20,7 @@ impl UseAsyncOptions {
 }
 
 /// State for an async future.
-#[derive(PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct UseAsyncState<T, E> {
     pub loading: bool,
     pub data: Option<T>,


### PR DESCRIPTION
This simply adds the `Clone` derive to the state, making it possible to extract the state and passing it to a sub-component for rendering.

It also adds IntelliJ project files to the list of files to ignore from git.