### PR TITLE
FIX:  #49 `use_debounce` and `use_debounce_state` don't work as expected

### DIFF
--- a/crates/yew-hooks/src/hooks/use_debounce_effect.rs
+++ b/crates/yew-hooks/src/hooks/use_debounce_effect.rs
@@ -61,7 +61,7 @@ use super::{use_debounce, use_unmount};
 #[hook]
 pub fn use_debounce_effect<Callback>(callback: Callback, millis: u32)
 where
-    Callback: FnOnce() + 'static,
+    Callback: Fn() + 'static,
 {
     let debounce = use_debounce(callback, millis);
 
@@ -89,7 +89,7 @@ pub fn use_debounce_effect_with_deps<Callback, Dependents>(
     millis: u32,
     deps: Dependents,
 ) where
-    Callback: FnOnce() + 'static,
+    Callback: Fn() + 'static,
     Dependents: PartialEq + 'static,
 {
     let debounce = use_debounce(callback, millis);

--- a/crates/yew-hooks/src/hooks/use_debounce_state.rs
+++ b/crates/yew-hooks/src/hooks/use_debounce_state.rs
@@ -6,6 +6,7 @@ use yew::prelude::*;
 use super::use_debounce;
 
 /// State handle for the [`use_debounce_state`] hook.
+#[derive(Clone)]
 pub struct UseDebounceStateHandle<T> {
     inner: UseStateHandle<T>,
     set: Rc<dyn Fn(T)>,
@@ -23,15 +24,6 @@ impl<T> Deref for UseDebounceStateHandle<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.inner
-    }
-}
-
-impl<T> Clone for UseDebounceStateHandle<T> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            set: self.set.clone(),
-        }
     }
 }
 
@@ -79,7 +71,7 @@ where
 pub fn use_debounce_state<T, F>(init_fn: F, millis: u32) -> UseDebounceStateHandle<T>
 where
     T: 'static,
-    F: FnOnce() -> T,
+    F: Fn() -> T,
 {
     let value = use_mut_ref(|| None);
     let inner = use_state(init_fn);

--- a/crates/yew-hooks/src/hooks/use_list.rs
+++ b/crates/yew-hooks/src/hooks/use_list.rs
@@ -18,7 +18,7 @@ impl<T> UseListHandle<T> {
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed
-    pub fn current(&self) -> Ref<Vec<T>> {
+    pub fn current(&'_ self) -> Ref<'_, Vec<T>> {
         self.inner.borrow()
     }
 

--- a/crates/yew-hooks/src/hooks/use_map.rs
+++ b/crates/yew-hooks/src/hooks/use_map.rs
@@ -19,7 +19,7 @@ impl<K, V> UseMapHandle<K, V> {
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed
-    pub fn current(&self) -> Ref<HashMap<K, V>> {
+    pub fn current(&'_ self) -> Ref<'_, HashMap<K, V>> {
         self.inner.borrow()
     }
 

--- a/crates/yew-hooks/src/hooks/use_queue.rs
+++ b/crates/yew-hooks/src/hooks/use_queue.rs
@@ -19,7 +19,7 @@ impl<T> UseQueueHandle<T> {
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed
-    pub fn current(&self) -> Ref<VecDeque<T>> {
+    pub fn current(&'_ self) -> Ref<'_, VecDeque<T>> {
         self.inner.borrow()
     }
 

--- a/crates/yew-hooks/src/hooks/use_set.rs
+++ b/crates/yew-hooks/src/hooks/use_set.rs
@@ -19,7 +19,7 @@ impl<T> UseSetHandle<T> {
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed
-    pub fn current(&self) -> Ref<HashSet<T>> {
+    pub fn current(&'_ self) -> Ref<'_, HashSet<T>> {
         self.inner.borrow()
     }
 


### PR DESCRIPTION
Fixes #39 and #49.

This PR:
- fixes some missing elided lifetime compiler warnings
- replaces `FnOnce()` `Callback` trait with `Fn()` in `use_debounce`, `use_debounce_effect`, and `use_debounce_state` so that the callback can be called multiple times;
- replaces `use_timeout` call in `use_debounce` with its own implementation that:
  - prevents the callback from being called until the `use_debounce` handle's `run()` function is invoked;
  - allows the callback to be called multiple times.